### PR TITLE
Fix syntax error in pod visionOS shim

### DIFF
--- a/ios/pod_visionos_patch.rb
+++ b/ios/pod_visionos_patch.rb
@@ -21,7 +21,8 @@ module Pod
     # call to the iOS proxy so CocoaPods can continue resolving dependencies
     # without understanding the new platform.
     def visionos
-      Pod::UI.warn('CocoaPods 1.13+ is recommended for visionOS support. Falling back to iOS configuration for compatibility.')
+      message = 'CocoaPods 1.13+ is recommended for visionOS support. Falling back to iOS configuration for compatibility.'
+      Pod::UI.warn(message)
       ios
     end
   end


### PR DESCRIPTION
## Summary
- assign the visionOS compatibility warning to a local variable before logging
- avoid Ruby parsing issues that were caused by the long inline string literal

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f1d94dd99c8324b19f5933b307c28b