### PR TITLE
Add CocoaPods CDN source to Podfile

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,5 @@
 # Resolve react_native_pods.rb with node to allow for hoisting
+source 'https://cdn.cocoapods.org/'
 require_relative './pod_visionos_patch'
 require Pod::Executable.execute_command('node', ['-p',
   'require.resolve(


### PR DESCRIPTION
## Summary
- add the CocoaPods CDN spec repository to the Podfile so SocketRocket 0.7.1 and other pods resolve correctly during installation

## Testing
- not run (macOS tooling unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f1ee7696bc8324ac7b18048dae3fe4