### PR TITLE
Fix Apple Silicon ffi pod install error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ ruby ">= 2.6.10"
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+# `ffi` 1.16+ ships universal binaries that work on Apple Silicon without requiring Rosetta.
+gem 'ffi', '>= 1.16.3'

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ cd ios && pod install
    ```bash
    npx pod-install ios
    ```
+   If you invoke `pod install` manually on Apple Silicon and see an error about `ffi` or `json`
+   extensions being built for `x86_64`, install the arm64-native gems first:
+   ```bash
+   bundle install
+   bundle exec pod install
+   # or, if you rely on the system Ruby:
+   sudo gem uninstall ffi json
+   sudo arch -arm64 gem install ffi:1.16.3 json
+   ```
 3. Launch the demo application:
    ```bash
    npm start


### PR DESCRIPTION
## Summary
- add an explicit ffi dependency so bundler installs a universal binary on Apple Silicon
- document the Apple Silicon pod install workaround in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1f0389be88324ae7caa02f7e00016