### PR TITLE
Fix Hermes dependencies for iOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ cd ios && pod install
    sudo gem uninstall ffi json
    sudo arch -arm64 gem install ffi:1.16.3 json
    ```
-3. Launch the demo application:
+3. Confirm Hermes is enabled (ThreadForge depends on it for the background runtime). The default
+   React Native template already sets `USE_HERMES=1`, so only change this if you previously disabled
+   Hermes.
+4. Launch the demo application:
    ```bash
    npm start
    npm run ios

--- a/packages/react-native-threadforge/README.md
+++ b/packages/react-native-threadforge/README.md
@@ -20,7 +20,8 @@ cd ios && pod install
 ```
 
 ThreadForge works with the default Hermes engine on React Native 0.73+. No manual native changes are
-required.
+required. If you disable Hermes for any reason, re-enable it on iOS by keeping `USE_HERMES=1` in your
+`Podfile` (ThreadForge creates a Hermes runtime to execute background work).
 
 ---
 

--- a/packages/react-native-threadforge/react-native-threadforge.podspec
+++ b/packages/react-native-threadforge/react-native-threadforge.podspec
@@ -18,6 +18,14 @@ Pod::Spec.new do |s|
   s.public_header_files = "ios/**/*.h"
   s.requires_arc = true
   s.dependency "React-Core"
+  s.dependency "React-jsi"
+
+  hermes_enabled = ENV['USE_HERMES'] != '0'
+  if hermes_enabled
+    s.dependency "React-hermes"
+  else
+    Pod::UI.warn('ThreadForge requires Hermes. Set USE_HERMES=1 in your Podfile to build the iOS target.')
+  end
   s.compiler_flags = "-std=c++17"
   s.pod_target_xcconfig = {
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",


### PR DESCRIPTION
## Summary
- declare React-jsi and React-hermes dependencies in the podspec so the Hermes runtime is linked on iOS
- warn consumers when Hermes is disabled because the library depends on it
- document the Hermes requirement in both the project and package READMEs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f1f20589e48324b48fde099cfd046d